### PR TITLE
Lê todo o buffer de entrada por iteração ao invés de 1 byte

### DIFF
--- a/DataLogger.py
+++ b/DataLogger.py
@@ -29,7 +29,12 @@ class CSVLogger(DataLogger):
         return file
 
     def write(self, data):
-        self.writer.writerow(data)
+        dataX = data[0]
+        dataY = data[1]
+        if len(dataX) != len(dataY): raise ValueError
+
+        for index in range(0, len(dataX)):
+            self.writer.writerow([dataX[index], dataY[index]])
 
     def flush(self):
         self.file.flush()
@@ -52,14 +57,19 @@ class XLSLogger(DataLogger):
         return file
 
     def write(self, data):
-        col = self.sampleCount % self.maxCols + 1
-        row = (self.sampleCount // self.maxCols) * 2 + 1
-        if col == 1:
-            self.amostras.write(row, 0, 'Medida')
-            self.amostras.write(row + 1, 0, 'Horário')
-        self.amostras.write(row, col, data[1])
-        self.amostras.write(row + 1, col, data[0])
-        self.sampleCount = self.sampleCount + 1
+        dataX = data[0]
+        dataY = data[1]
+        if len(dataX) != len(dataY): raise ValueError
+
+        for index in range(0, len(dataX)):
+            col = self.sampleCount % self.maxCols + 1
+            row = (self.sampleCount // self.maxCols) * 2 + 1
+            if col == 1:
+                self.amostras.write(row, 0, 'Medida')
+                self.amostras.write(row + 1, 0, 'Horário')
+            self.amostras.write(row, col, dataY[index])
+            self.amostras.write(row + 1, col, dataX[index])
+            self.sampleCount = self.sampleCount + 1
 
     def flush(self):
         self.book.save(self.file)

--- a/Sampler.py
+++ b/Sampler.py
@@ -15,11 +15,16 @@ class Sampler:
         self.lastTimestamp = datetime.now()
         self.timeElaspsed = 0
 
-    def getSample(self):
-        if self.sampleSource.available() > 1:
+    def getSamples(self):
+        dataX = []
+        dataY = []
+        while self.sampleSource.available() > 1:
             now = datetime.now()
             delta = now - self.lastTimestamp
             self.lastTimestamp = now
             self.timeElaspsed = self.timeElaspsed + delta.total_seconds()
             valor = self.sampleSource.readUint16() * (self.fullScale / self.maxAD) * self.ratio
-            return (self.timeElaspsed, valor)
+            dataX.append(self.timeElaspsed)
+            dataY.append(valor)
+        if len(dataX) > 0: return [dataX, dataY]
+        else: return None

--- a/SamplingWindow.py
+++ b/SamplingWindow.py
@@ -8,6 +8,18 @@ class SamplingWindow(CurveWindow):
         self.xdata = []
         self.ydata = []
 
+    def addSamples(self, x, y):
+        left, right = self.getXLimit()
+        if x[-1] > right:
+            self.setXLimit(x[-1] - (right - left), x[-1])
+
+        self.xdata.extend(x)
+        self.ydata.extend(y)
+        self.xdata = self.xdata[-self.maxSamples:]
+        self.ydata = self.ydata[-self.maxSamples:]
+        self.setData(self.xdata, self.ydata)
+
+
     def addSample(self, x, y):
         left, right = self.getXLimit()
         if x > right:

--- a/main.py
+++ b/main.py
@@ -44,7 +44,7 @@ class MainFrame(tk.Frame):
         self.curve.setYLimit(0, 6)
 
     def updateCurve(self, x, y):
-        self.curve.addSample(x, y)
+        self.curve.addSamples(x, y)
         self.fileTask.write([x, y])
 
     def startCapture(self, comsettings, filePath):
@@ -95,7 +95,7 @@ class MainFrame(tk.Frame):
 
     def sampleLoop(self):
         if self.serialPort.isOpen():
-            sample = self.sampler.getSample()
+            sample = self.sampler.getSamples()
             if sample : self.updateCurve(sample[0], sample[1])
             self.master.after(100, self.sampleLoop)
 


### PR DESCRIPTION
A cada chamada de MainFrame.serialLoop lê todos as palavras de 2 bytes disponíveis no buffer. Além disso o formato passado de dados muda de [[x, y], [x, y], [x, y],...] para [[x, x, x, ...], [y, y, y, ...]] para facilitar a inserção dos dados no gráfico.