### PR TITLE
Chama MainFrame.stopCapture ao fechar a janela

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,7 +87,7 @@ class MainFrame(tk.Frame):
             self.file = None
         
     def closeWindow(self):
-        self.closeFile()
+        self.stopCapture()
         self.master.destroy()
 
     def startLoop(self):


### PR DESCRIPTION
Chama MainFrame.stopCapture em MainFrame.closeWindow ao invés de MainFrame.closeFile