### PR TITLE
Corrigido nome de porta maior que COM9 para Windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from tkinter import filedialog
 import tkinter as tk
 
+import sys
 from DataLogger import CSVLogger, XLSLogger
 from LogReader import CSVReader, XLSReader
 from Sampler import Sampler
@@ -88,6 +89,8 @@ class MainFrame(tk.Frame):
         self.fileTask = FileWriter(self.file)
         self.fileTask.start()
 
+        if sys.platform == 'win32':
+            comsettings['port'] = '\\\\.\\' + comsettings['port']
         self.sampler.begin(comsettings)
         self.startLoop()
 


### PR DESCRIPTION
Para portas com numeração acima  de 9 (ex. COM10) deve-se adicionar o prefixo \\.\  ao  nome da porta: (\\.\COM10).